### PR TITLE
Add admin-only eval command and enhance sticker processing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,0 @@
-# Configurações do Bot
-COMMAND_PREFIX=/ # Prefixo para comandos do bot (ex: /, !, #)
-
-# Configurações de Armazenamento de Dados
-STORE_PATH=./temp/ # Caminho relativo para a pasta onde os arquivos de dados serão salvos (ex: ./temp/)

--- a/app/controllers/messageController.js
+++ b/app/controllers/messageController.js
@@ -142,9 +142,12 @@ const handleMessages = async (update, sock) => {
       for (const messageInfo of update.messages) {
         const extractedText = extractMessageContent(messageInfo);
         if (extractedText.startsWith(COMMAND_PREFIX)) {
-          const commandArgs = extractedText.substring(COMMAND_PREFIX.length).split(' ');
-          const command = commandArgs[0];
-          const args = commandArgs.slice(1);
+          // Extrai o comando e o restante como um único argumento (preserva quebras de linha e espaços)
+          const commandBody = extractedText.substring(COMMAND_PREFIX.length);
+          const match = commandBody.match(/^(\S+)([\s\S]*)$/);
+          const command = match ? match[1] : '';
+          // args[0] contém todo o texto após o comando, incluindo quebras de linha
+          const args = match && match[2] !== undefined ? [match[2].trimStart()] : [];
 
           const isGroupMessage = messageInfo.key.remoteJid.endsWith('@g.us');
           const remoteJid = messageInfo.key.remoteJid;
@@ -202,6 +205,7 @@ const handleMessages = async (update, sock) => {
             }
             case 'sticker':
             case 's':
+              console.log(args);
               // Envia o texto do comando (args) para o módulo de sticker
               await processSticker(sock, messageInfo, senderJid, remoteJid, expirationMessage, senderName, args.join(' '));
               break;

--- a/app/controllers/messageController.js
+++ b/app/controllers/messageController.js
@@ -202,8 +202,8 @@ const handleMessages = async (update, sock) => {
             }
             case 'sticker':
             case 's':
-              await processSticker(sock, messageInfo, senderJid, remoteJid, expirationMessage, senderName);
-
+              // Envia o texto do comando (args) para o módulo de sticker
+              await processSticker(sock, messageInfo, senderJid, remoteJid, expirationMessage, senderName, args.join(' '));
               break;
 
             case 'info':

--- a/app/modules/stickerModule/addStickerMetadata.js
+++ b/app/modules/stickerModule/addStickerMetadata.js
@@ -1,38 +1,101 @@
 /**
- * Adiciona metadados ao sticker
- * @param {string} stickerPath - Caminho do arquivo de sticker
- * @param {string} packName - Nome do pacote
- * @param {string} packAuthor - Autor do pacote
- * @returns {Promise<string>} - Caminho do sticker com metadados
+ * Módulo responsável por adicionar metadados EXIF a stickers WebP.
+ *
+ * @module addStickerMetadata
+ */
+
+/**
+ * Módulo de manipulação de arquivos com Promises.
+ * @const
  */
 const fs = require('fs').promises;
+
+/**
+ * Módulo para manipulação de caminhos de arquivos.
+ * @const
+ */
 const path = require('path');
+
+/**
+ * Módulo utilitário do Node.js.
+ * @const
+ */
 const util = require('util');
+
+/**
+ * Executa comandos no shell.
+ * @const
+ */
 const { exec } = require('child_process');
+
+/**
+ * Versão promisificada do exec.
+ * @const
+ */
 const execProm = util.promisify(exec);
+
+/**
+ * Módulo de logger customizado.
+ * @const
+ */
 const logger = require('../../utils/logger/loggerModule');
 
+/**
+ * Diretório temporário para stickers processados.
+ * @const {string}
+ */
 const TEMP_DIR = path.join(process.cwd(), 'temp', 'stickers');
 
+/**
+ * Adiciona metadados EXIF a um sticker WebP.
+ *
+ * @async
+ * @function addStickerMetadata
+ * @param {string} stickerPath - Caminho do arquivo de sticker WebP original.
+ * @param {string} packName - Nome do pacote de stickers.
+ * @param {string} packAuthor - Nome do autor do pacote.
+ * @returns {Promise<string>} Caminho do novo sticker WebP com metadados, ou o original em caso de erro.
+ */
 async function addStickerMetadata(stickerPath, packName, packAuthor) {
   logger.info(`[StickerCommand] Adicionando metadados ao sticker. Nome: "${packName}", Autor: "${packAuthor}"`);
 
   try {
+    /**
+     * Estrutura dos metadados EXIF para o sticker.
+     * @type {Object}
+     */
     const exifData = {
       'sticker-pack-id': `com.omnizap.${Date.now()}`,
       'sticker-pack-name': packName,
       'sticker-pack-publisher': packAuthor,
     };
 
+    /**
+     * Caminho do arquivo EXIF temporário.
+     * @type {string}
+     */
     const exifPath = path.join(TEMP_DIR, `exif_${Date.now()}.exif`);
 
+    /**
+     * Buffer de atributos EXIF padrão para WebP.
+     * @type {Buffer}
+     */
     const exifAttr = Buffer.from([0x49, 0x49, 0x2a, 0x00, 0x08, 0x00, 0x00, 0x00, 0x01, 0x00, 0x41, 0x57, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x16, 0x00, 0x00, 0x00]);
+    /**
+     * Buffer do JSON dos metadados.
+     * @type {Buffer}
+     */
     const jsonBuffer = Buffer.from(JSON.stringify(exifData), 'utf8');
+    /**
+     * Buffer final EXIF.
+     * @type {Buffer}
+     */
     const exifBuffer = Buffer.concat([exifAttr, jsonBuffer]);
     exifBuffer.writeUIntLE(jsonBuffer.length, 14, 4);
 
     await fs.writeFile(exifPath, exifBuffer);
 
+    // Verifica se o webpmux está instalado
     try {
       await execProm('which webpmux');
     } catch (error) {
@@ -45,6 +108,10 @@ async function addStickerMetadata(stickerPath, packName, packAuthor) {
       }
     }
 
+    /**
+     * Caminho do sticker final com metadados.
+     * @type {string}
+     */
     const outputPath = path.join(TEMP_DIR, `final_${Date.now()}.webp`);
     await execProm(`webpmux -set exif "${exifPath}" "${stickerPath}" -o "${outputPath}"`);
 
@@ -62,4 +129,8 @@ async function addStickerMetadata(stickerPath, packName, packAuthor) {
   }
 }
 
+/**
+ * Exporta a função principal do módulo.
+ * @type {{ addStickerMetadata: function(string, string, string): Promise<string> }}
+ */
 module.exports = { addStickerMetadata };

--- a/app/modules/stickerModule/addStickerMetadata.js
+++ b/app/modules/stickerModule/addStickerMetadata.js
@@ -1,0 +1,65 @@
+/**
+ * Adiciona metadados ao sticker
+ * @param {string} stickerPath - Caminho do arquivo de sticker
+ * @param {string} packName - Nome do pacote
+ * @param {string} packAuthor - Autor do pacote
+ * @returns {Promise<string>} - Caminho do sticker com metadados
+ */
+const fs = require('fs').promises;
+const path = require('path');
+const util = require('util');
+const { exec } = require('child_process');
+const execProm = util.promisify(exec);
+const logger = require('../../utils/logger/loggerModule');
+
+const TEMP_DIR = path.join(process.cwd(), 'temp', 'stickers');
+
+async function addStickerMetadata(stickerPath, packName, packAuthor) {
+  logger.info(`[StickerCommand] Adicionando metadados ao sticker. Nome: "${packName}", Autor: "${packAuthor}"`);
+
+  try {
+    const exifData = {
+      'sticker-pack-id': `com.omnizap.${Date.now()}`,
+      'sticker-pack-name': packName,
+      'sticker-pack-publisher': packAuthor,
+    };
+
+    const exifPath = path.join(TEMP_DIR, `exif_${Date.now()}.exif`);
+
+    const exifAttr = Buffer.from([0x49, 0x49, 0x2a, 0x00, 0x08, 0x00, 0x00, 0x00, 0x01, 0x00, 0x41, 0x57, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x16, 0x00, 0x00, 0x00]);
+    const jsonBuffer = Buffer.from(JSON.stringify(exifData), 'utf8');
+    const exifBuffer = Buffer.concat([exifAttr, jsonBuffer]);
+    exifBuffer.writeUIntLE(jsonBuffer.length, 14, 4);
+
+    await fs.writeFile(exifPath, exifBuffer);
+
+    try {
+      await execProm('which webpmux');
+    } catch (error) {
+      logger.warn('[StickerCommand] webpmux não encontrado, tentando instalar...');
+      try {
+        await execProm('apt-get update && apt-get install -y webp');
+      } catch (installError) {
+        logger.error(`[StickerCommand] Falha ao instalar webpmux: ${installError.message}`);
+        throw new Error('webpmux não está instalado e não foi possível instalá-lo');
+      }
+    }
+
+    const outputPath = path.join(TEMP_DIR, `final_${Date.now()}.webp`);
+    await execProm(`webpmux -set exif "${exifPath}" "${stickerPath}" -o "${outputPath}"`);
+
+    await fs.unlink(exifPath);
+
+    logger.info(`[StickerCommand] Metadados adicionados com sucesso. Sticker final: ${outputPath}`);
+    return outputPath;
+  } catch (error) {
+    logger.error(`[StickerCommand] Erro ao adicionar metadados: ${error.message}`, {
+      label: 'StickerCommand.addStickerMetadata',
+      error: error.stack,
+    });
+
+    return stickerPath;
+  }
+}
+
+module.exports = { addStickerMetadata };

--- a/app/modules/stickerModule/stickerCommand.js
+++ b/app/modules/stickerModule/stickerCommand.js
@@ -129,7 +129,19 @@ async function convertToWebp(inputPath, mediaType, userId, uniqueId) {
     }
     const filtro = mediaType === 'video' ? 'fps=10,scale=512:512' : 'scale=512:512';
     const ffmpegCommand = `ffmpeg -i "${inputPath}" -vcodec libwebp -lossless 1 -loop 0 -preset default -an -vf "${filtro}" "${outputPath}"`;
-    await execProm(ffmpegCommand);
+    let ffmpegResult;
+    try {
+      ffmpegResult = await execProm(ffmpegCommand);
+    } catch (ffmpegErr) {
+      logger.error(`Erro na execução do FFmpeg: ${ffmpegErr.message}`);
+      if (ffmpegErr.stderr) {
+        logger.error(`FFmpeg stderr: ${ffmpegErr.stderr}`);
+      }
+      throw new Error(`Falha ao converter mídia para sticker (FFmpeg): ${ffmpegErr.message}`);
+    }
+    if (ffmpegResult && ffmpegResult.stderr) {
+      logger.debug(`FFmpeg stderr: ${ffmpegResult.stderr}`);
+    }
     await fs.access(outputPath);
     logger.info(`StickerCommand Conversão bem-sucedida para: ${outputPath}`);
     return outputPath;

--- a/app/modules/stickerModule/stickerCommand.js
+++ b/app/modules/stickerModule/stickerCommand.js
@@ -116,6 +116,13 @@ async function convertToWebp(inputPath, mediaType, userId, uniqueId) {
     // Garante que o diretório de destino existe
     await fs.mkdir(userStickerDir, { recursive: true });
 
+    // Validação explícita do tipo de mídia
+    const allowedTypes = ['image', 'video', 'sticker'];
+    if (!allowedTypes.includes(mediaType)) {
+      logger.error(`Tipo de mídia não suportado para conversão: ${mediaType}`);
+      throw new Error(`Tipo de mídia não suportado: ${mediaType}`);
+    }
+
     if (mediaType === 'sticker') {
       await fs.copyFile(inputPath, outputPath);
       return outputPath;

--- a/app/modules/stickerModule/stickerCommand.js
+++ b/app/modules/stickerModule/stickerCommand.js
@@ -1,28 +1,3 @@
-/**
- * Faz o parsing do texto recebido para packName e packAuthor.
- * Se o texto contiver '/', separa em dois: packName/packAuthor.
- * Caso contrário, usa o texto como packName e o senderName como autor.
- * @param {string} text
- * @param {string} senderName
- * @returns {{ packName: string, packAuthor: string }}
- */
-function parseStickerMetaText(text, senderName) {
-  let packName = 'OmniZap';
-  let packAuthor = senderName || 'OmniZap';
-  if (text) {
-    // Preserva quebras de linha e separa na primeira barra encontrada
-    const idx = text.indexOf('/');
-    if (idx !== -1) {
-      const name = text.slice(0, idx).trim();
-      const author = text.slice(idx + 1).trim();
-      if (name) packName = name;
-      if (author) packAuthor = author;
-    } else if (text.trim()) {
-      packName = text.trim();
-    }
-  }
-  return { packName, packAuthor };
-}
 const { addStickerMetadata } = require('./addStickerMetadata');
 /**
  * Módulo responsável pelo processamento de stickers a partir de mídias recebidas.
@@ -182,6 +157,31 @@ async function convertToWebp(inputPath, mediaType, userId, uniqueId) {
     });
     throw new Error(`Erro na conversão para webp: ${error.message}`);
   }
+}
+
+/**
+ * Faz o parsing do texto recebido para packName e packAuthor.
+ * Se o texto contiver '/', separa em dois: packName/packAuthor.
+ * Caso contrário, usa o texto como packName e o senderName como autor.
+ * @param {string} text
+ * @param {string} senderName
+ * @returns {{ packName: string, packAuthor: string }}
+ */
+function parseStickerMetaText(text, senderName) {
+  let packName = 'OmniZap';
+  let packAuthor = senderName || 'OmniZap';
+  if (text) {
+    const idx = text.indexOf('/');
+    if (idx !== -1) {
+      const name = text.slice(0, idx).trim();
+      const author = text.slice(idx + 1).trim();
+      if (name) packName = name;
+      if (author) packAuthor = author;
+    } else if (text.trim()) {
+      packName = text.trim();
+    }
+  }
+  return { packName, packAuthor };
 }
 
 /**

--- a/app/modules/stickerModule/stickerCommand.js
+++ b/app/modules/stickerModule/stickerCommand.js
@@ -113,6 +113,9 @@ async function convertToWebp(inputPath, mediaType, userId, uniqueId) {
   const outputPath = path.join(userStickerDir, `sticker_${uniqueId}.webp`);
 
   try {
+    // Garante que o diretório de destino existe
+    await fs.mkdir(userStickerDir, { recursive: true });
+
     if (mediaType === 'sticker') {
       await fs.copyFile(inputPath, outputPath);
       return outputPath;

--- a/app/modules/stickerModule/stickerCommand.js
+++ b/app/modules/stickerModule/stickerCommand.js
@@ -1,57 +1,4 @@
-/**
- * Adiciona metadados ao sticker
- * @param {string} stickerPath - Caminho do arquivo de sticker
- * @param {string} packName - Nome do pacote
- * @param {string} packAuthor - Autor do pacote
- * @returns {Promise<string>} - Caminho do sticker com metadados
- */
-async function addStickerMetadata(stickerPath, packName, packAuthor) {
-  logger.info(`[StickerCommand] Adicionando metadados ao sticker. Nome: "${packName}", Autor: "${packAuthor}"`);
-
-  try {
-    const exifData = {
-      'sticker-pack-id': `com.omnizap.${Date.now()}`,
-      'sticker-pack-name': packName,
-      'sticker-pack-publisher': packAuthor,
-    };
-
-    const exifPath = path.join(TEMP_DIR, `exif_${Date.now()}.exif`);
-
-    const exifAttr = Buffer.from([0x49, 0x49, 0x2a, 0x00, 0x08, 0x00, 0x00, 0x00, 0x01, 0x00, 0x41, 0x57, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x16, 0x00, 0x00, 0x00]);
-    const jsonBuffer = Buffer.from(JSON.stringify(exifData), 'utf8');
-    const exifBuffer = Buffer.concat([exifAttr, jsonBuffer]);
-    exifBuffer.writeUIntLE(jsonBuffer.length, 14, 4);
-
-    await fs.writeFile(exifPath, exifBuffer);
-
-    try {
-      await execProm('which webpmux');
-    } catch (error) {
-      logger.warn('[StickerCommand] webpmux não encontrado, tentando instalar...');
-      try {
-        await execProm('apt-get update && apt-get install -y webp');
-      } catch (installError) {
-        logger.error(`[StickerCommand] Falha ao instalar webpmux: ${installError.message}`);
-        throw new Error('webpmux não está instalado e não foi possível instalá-lo');
-      }
-    }
-
-    const outputPath = path.join(TEMP_DIR, `final_${Date.now()}.webp`);
-    await execProm(`webpmux -set exif "${exifPath}" "${stickerPath}" -o "${outputPath}"`);
-
-    await fs.unlink(exifPath);
-
-    logger.info(`[StickerCommand] Metadados adicionados com sucesso. Sticker final: ${outputPath}`);
-    return outputPath;
-  } catch (error) {
-    logger.error(`[StickerCommand] Erro ao adicionar metadados: ${error.message}`, {
-      label: 'StickerCommand.addStickerMetadata',
-      error: error.stack,
-    });
-
-    return stickerPath;
-  }
-}
+const { addStickerMetadata } = require('./addStickerMetadata');
 /**
  * Módulo responsável pelo processamento de stickers a partir de mídias recebidas.
  * Inclui funções para garantir diretórios temporários, extrair detalhes de mídia,
@@ -316,5 +263,4 @@ async function processSticker(sock, messageInfo, senderJid, remoteJid, expiratio
  */
 module.exports = {
   processSticker,
-  addStickerMetadata,
 };

--- a/app/modules/stickerModule/stickerCommand.js
+++ b/app/modules/stickerModule/stickerCommand.js
@@ -10,16 +10,15 @@ function parseStickerMetaText(text, senderName) {
   let packName = 'OmniZap';
   let packAuthor = senderName || 'OmniZap';
   if (text) {
-    // Normaliza para garantir que '/' em nova linha também seja reconhecido
-    const normalized = text.replace(/\r?\n/g, ' ');
-    const idx = normalized.indexOf('/');
+    // Preserva quebras de linha e separa na primeira barra encontrada
+    const idx = text.indexOf('/');
     if (idx !== -1) {
-      const name = normalized.slice(0, idx).trim();
-      const author = normalized.slice(idx + 1).trim();
+      const name = text.slice(0, idx).trim();
+      const author = text.slice(idx + 1).trim();
       if (name) packName = name;
       if (author) packAuthor = author;
-    } else if (normalized.trim()) {
-      packName = normalized.trim();
+    } else if (text.trim()) {
+      packName = text.trim();
     }
   }
   return { packName, packAuthor };

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "proper-lockfile": "^4.1.2",
         "qrcode-terminal": "^0.12.0",
         "stream-json": "^1.9.1",
+        "uuid": "^13.0.0",
         "winston": "^3.17.0",
         "winston-daily-rotate-file": "^5.0.0"
       },
@@ -1730,6 +1731,19 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
     },
     "node_modules/when": {
       "version": "3.7.8",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "proper-lockfile": "^4.1.2",
     "qrcode-terminal": "^0.12.0",
     "stream-json": "^1.9.1",
+    "uuid": "^13.0.0",
     "winston": "^3.17.0",
     "winston-daily-rotate-file": "^5.0.0"
   },


### PR DESCRIPTION
Introduce an admin-only JavaScript `eval` command for debugging, improve sticker generation with UUIDs, ensure output directories exist, and add media type validation. Enhance error logging for FFmpeg, implement a timeout for conversions, and embed EXIF metadata in generated stickers, allowing for custom pack names and authors. Refactor metadata handling for better organization.