### PR TITLE
Persists last used sticker metadata

### DIFF
--- a/app/modules/stickerModule/addStickerMetadata.js
+++ b/app/modules/stickerModule/addStickerMetadata.js
@@ -1,136 +1,55 @@
-/**
- * Módulo responsável por adicionar metadados EXIF a stickers WebP.
- *
- * @module addStickerMetadata
- */
-
-/**
- * Módulo de manipulação de arquivos com Promises.
- * @const
- */
 const fs = require('fs').promises;
-
-/**
- * Módulo para manipulação de caminhos de arquivos.
- * @const
- */
 const path = require('path');
-
-/**
- * Módulo utilitário do Node.js.
- * @const
- */
 const util = require('util');
-
-/**
- * Executa comandos no shell.
- * @const
- */
 const { exec } = require('child_process');
-
-/**
- * Versão promisificada do exec.
- * @const
- */
 const execProm = util.promisify(exec);
-
-/**
- * Módulo de logger customizado.
- * @const
- */
 const logger = require('../../utils/logger/loggerModule');
-
-/**
- * Diretório temporário para stickers processados.
- * @const {string}
- */
 const TEMP_DIR = path.join(process.cwd(), 'temp', 'stickers');
 
-/**
- * Adiciona metadados EXIF a um sticker WebP.
- *
- * @async
- * @function addStickerMetadata
- * @param {string} stickerPath - Caminho do arquivo de sticker WebP original.
- * @param {string} packName - Nome do pacote de stickers.
- * @param {string} packAuthor - Nome do autor do pacote.
- * @returns {Promise<string>} Caminho do novo sticker WebP com metadados, ou o original em caso de erro.
- */
 async function addStickerMetadata(stickerPath, packName, packAuthor) {
-  logger.info(`[StickerCommand] Adicionando metadados ao sticker. Nome: "${packName}", Autor: "${packAuthor}"`);
+  logger.info(`addStickerMetadata Adicionando metadados ao sticker. Nome: "${packName}", Autor: "${packAuthor}"`);
 
   try {
-    /**
-     * Estrutura dos metadados EXIF para o sticker.
-     * @type {Object}
-     */
     const exifData = {
       'sticker-pack-id': `com.omnizap.${Date.now()}`,
       'sticker-pack-name': packName,
       'sticker-pack-publisher': packAuthor,
     };
 
-    /**
-     * Caminho do arquivo EXIF temporário.
-     * @type {string}
-     */
     const exifPath = path.join(TEMP_DIR, `exif_${Date.now()}.exif`);
-
-    /**
-     * Buffer de atributos EXIF padrão para WebP.
-     * @type {Buffer}
-     */
     const exifAttr = Buffer.from([0x49, 0x49, 0x2a, 0x00, 0x08, 0x00, 0x00, 0x00, 0x01, 0x00, 0x41, 0x57, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x16, 0x00, 0x00, 0x00]);
-    /**
-     * Buffer do JSON dos metadados.
-     * @type {Buffer}
-     */
     const jsonBuffer = Buffer.from(JSON.stringify(exifData), 'utf8');
-    /**
-     * Buffer final EXIF.
-     * @type {Buffer}
-     */
     const exifBuffer = Buffer.concat([exifAttr, jsonBuffer]);
     exifBuffer.writeUIntLE(jsonBuffer.length, 14, 4);
 
     await fs.writeFile(exifPath, exifBuffer);
 
-    // Verifica se o webpmux está instalado
     try {
       await execProm('which webpmux');
     } catch (error) {
-      logger.warn('[StickerCommand] webpmux não encontrado, tentando instalar...');
+      logger.warn('addStickerMetadata webpmux não encontrado, tentando instalar...');
       try {
-        await execProm('apt-get update && apt-get install -y webp');
+        await execProm('apt-get update && apt install -y webp');
       } catch (installError) {
-        logger.error(`[StickerCommand] Falha ao instalar webpmux: ${installError.message}`);
+        logger.error(`addStickerMetadata Falha ao instalar webpmux: ${installError.message}`);
         throw new Error('webpmux não está instalado e não foi possível instalá-lo');
       }
     }
 
-    /**
-     * Caminho do sticker final com metadados.
-     * @type {string}
-     */
     const outputPath = path.join(TEMP_DIR, `final_${Date.now()}.webp`);
     await execProm(`webpmux -set exif "${exifPath}" "${stickerPath}" -o "${outputPath}"`);
 
     await fs.unlink(exifPath);
 
-    logger.info(`[StickerCommand] Metadados adicionados com sucesso. Sticker final: ${outputPath}`);
+    logger.info(`addStickerMetadata Metadados adicionados com sucesso. Sticker final: ${outputPath}`);
     return outputPath;
   } catch (error) {
-    logger.error(`[StickerCommand] Erro ao adicionar metadados: ${error.message}`, {
-      label: 'StickerCommand.addStickerMetadata',
+    logger.error(`addStickerMetadata Erro ao adicionar metadados: ${error.message}`, {
+      label: 'addStickerMetadata',
       error: error.stack,
     });
-
     return stickerPath;
   }
 }
 
-/**
- * Exporta a função principal do módulo.
- * @type {{ addStickerMetadata: function(string, string, string): Promise<string> }}
- */
 module.exports = { addStickerMetadata };

--- a/app/modules/stickerModule/addStickerMetadata.js
+++ b/app/modules/stickerModule/addStickerMetadata.js
@@ -62,5 +62,6 @@ async function addStickerMetadata(stickerPath, packName, packAuthor) {
     return stickerPath;
   }
 }
+//
 
 module.exports = { addStickerMetadata };

--- a/app/modules/stickerModule/addStickerMetadata.js
+++ b/app/modules/stickerModule/addStickerMetadata.js
@@ -4,12 +4,23 @@ const util = require('util');
 const { exec } = require('child_process');
 const execProm = util.promisify(exec);
 const logger = require('../../utils/logger/loggerModule');
+
 const TEMP_DIR = path.join(process.cwd(), 'temp', 'stickers');
+
+async function ensureDirectories(dir) {
+  try {
+    await fs.mkdir(dir, { recursive: true });
+  } catch (err) {
+    if (err.code !== 'EEXIST') throw err;
+  }
+}
 
 async function addStickerMetadata(stickerPath, packName, packAuthor) {
   logger.info(`addStickerMetadata Adicionando metadados ao sticker. Nome: "${packName}", Autor: "${packAuthor}"`);
 
   try {
+    await ensureDirectories(TEMP_DIR);
+
     const exifData = {
       'sticker-pack-id': `com.omnizap.${Date.now()}`,
       'sticker-pack-name': packName,

--- a/app/modules/stickerModule/convertToWebp.js
+++ b/app/modules/stickerModule/convertToWebp.js
@@ -1,0 +1,68 @@
+const fs = require('fs').promises;
+const path = require('path');
+const util = require('util');
+const { exec } = require('child_process');
+const execProm = util.promisify(exec);
+const logger = require('../../utils/logger/loggerModule');
+
+const TEMP_DIR = path.join(process.cwd(), 'temp', 'stickers');
+
+/**
+ * Converte um arquivo de mídia para o formato webp, pronto para sticker.
+ *
+ * @param {string} inputPath - Caminho do arquivo de mídia de entrada.
+ * @param {string} mediaType - Tipo da mídia (image, video, sticker).
+ * @param {string} userId - ID do usuário.
+ * @param {string} uniqueId - Identificador único para o sticker.
+ * @returns {Promise<string>} Caminho do arquivo webp gerado.
+ * @throws {Error} Se a conversão falhar.
+ */
+async function convertToWebp(inputPath, mediaType, userId, uniqueId) {
+  logger.info(`StickerCommand Convertendo mídia para webp. ID: ${uniqueId}, Tipo: ${mediaType}`);
+  const userStickerDir = path.join(TEMP_DIR, userId);
+  const outputPath = path.join(userStickerDir, `sticker_${uniqueId}.webp`);
+
+  try {
+    await fs.mkdir(userStickerDir, { recursive: true });
+
+    const allowedTypes = ['image', 'video', 'sticker'];
+    if (!allowedTypes.includes(mediaType)) {
+      logger.error(`Tipo de mídia não suportado para conversão: ${mediaType}`);
+      throw new Error(`Tipo de mídia não suportado: ${mediaType}`);
+    }
+
+    if (mediaType === 'sticker') {
+      await fs.copyFile(inputPath, outputPath);
+      return outputPath;
+    }
+    const filtro = mediaType === 'video' ? 'fps=10,scale=512:512' : 'scale=512:512';
+    const ffmpegCommand = `ffmpeg -i "${inputPath}" -vcodec libwebp -lossless 1 -loop 0 -preset default -an -vf "${filtro}" "${outputPath}"`;
+    let ffmpegResult;
+    try {
+      ffmpegResult = await execProm(ffmpegCommand, { timeout: 20000 });
+    } catch (ffmpegErr) {
+      if (ffmpegErr.killed || ffmpegErr.signal === 'SIGTERM' || ffmpegErr.code === 'ETIMEDOUT') {
+        logger.error('FFmpeg finalizado por timeout.');
+        throw new Error('Conversão cancelada: tempo limite excedido (timeout).');
+      }
+      logger.error(`Erro na execução do FFmpeg: ${ffmpegErr.message}`);
+      if (ffmpegErr.stderr) {
+        logger.error(`FFmpeg stderr: ${ffmpegErr.stderr}`);
+      }
+      throw new Error(`Falha ao converter mídia para sticker (FFmpeg): ${ffmpegErr.message}`);
+    }
+    if (ffmpegResult && ffmpegResult.stderr) {
+      logger.debug(`FFmpeg stderr: ${ffmpegResult.stderr}`);
+    }
+    await fs.access(outputPath);
+    logger.info(`StickerCommand Conversão bem-sucedida para: ${outputPath}`);
+    return outputPath;
+  } catch (error) {
+    logger.error(`StickerCommand.convertToWebp Erro na conversão: ${error.message}`, {
+      error: error.stack,
+    });
+    throw new Error(`Erro na conversão para webp: ${error.message}`);
+  }
+}
+
+module.exports = { convertToWebp };

--- a/app/modules/stickerModule/stickerCommand.js
+++ b/app/modules/stickerModule/stickerCommand.js
@@ -209,7 +209,8 @@ async function processSticker(sock, messageInfo, senderJid, remoteJid, expiratio
     stickerPath = await convertToWebp(processingMediaPath, mediaType, formattedUser, uniqueId);
 
     const { packName, packAuthor } = parseStickerMetaText(extraText, senderName);
-    stickerPath = await addStickerMetadata(stickerPath, packName, packAuthor);
+    // Passa contexto para replaces: senderName e userId
+    stickerPath = await addStickerMetadata(stickerPath, packName, packAuthor, { senderName, userId: formattedUser });
 
     let stickerBuffer = null;
     try {

--- a/app/modules/stickerModule/stickerCommand.js
+++ b/app/modules/stickerModule/stickerCommand.js
@@ -1,4 +1,5 @@
 const { addStickerMetadata } = require('./addStickerMetadata');
+const { convertToWebp } = require('./convertToWebp');
 /**
  * Módulo responsável pelo processamento de stickers a partir de mídias recebidas.
  * Inclui funções para garantir diretórios temporários, extrair detalhes de mídia,
@@ -96,64 +97,6 @@ function checkMediaSize(mediaKey, mediaType, maxFileSize = MAX_FILE_SIZE) {
     return false;
   }
   return true;
-}
-
-/**
- * Converte um arquivo de mídia para o formato webp, pronto para sticker.
- *
- * @param {string} inputPath - Caminho do arquivo de mídia de entrada.
- * @param {string} mediaType - Tipo da mídia (image, video, sticker).
- * @param {string} userId - ID do usuário.
- * @param {string} uniqueId - Identificador único para o sticker.
- * @returns {Promise<string>} Caminho do arquivo webp gerado.
- * @throws {Error} Se a conversão falhar.
- */
-async function convertToWebp(inputPath, mediaType, userId, uniqueId) {
-  logger.info(`StickerCommand Convertendo mídia para webp. ID: ${uniqueId}, Tipo: ${mediaType}`);
-  const userStickerDir = path.join(TEMP_DIR, userId);
-  const outputPath = path.join(userStickerDir, `sticker_${uniqueId}.webp`);
-
-  try {
-    await fs.mkdir(userStickerDir, { recursive: true });
-
-    const allowedTypes = ['image', 'video', 'sticker'];
-    if (!allowedTypes.includes(mediaType)) {
-      logger.error(`Tipo de mídia não suportado para conversão: ${mediaType}`);
-      throw new Error(`Tipo de mídia não suportado: ${mediaType}`);
-    }
-
-    if (mediaType === 'sticker') {
-      await fs.copyFile(inputPath, outputPath);
-      return outputPath;
-    }
-    const filtro = mediaType === 'video' ? 'fps=10,scale=512:512' : 'scale=512:512';
-    const ffmpegCommand = `ffmpeg -i "${inputPath}" -vcodec libwebp -lossless 1 -loop 0 -preset default -an -vf "${filtro}" "${outputPath}"`;
-    let ffmpegResult;
-    try {
-      ffmpegResult = await execProm(ffmpegCommand, { timeout: 20000 });
-    } catch (ffmpegErr) {
-      if (ffmpegErr.killed || ffmpegErr.signal === 'SIGTERM' || ffmpegErr.code === 'ETIMEDOUT') {
-        logger.error('FFmpeg finalizado por timeout.');
-        throw new Error('Conversão cancelada: tempo limite excedido (timeout).');
-      }
-      logger.error(`Erro na execução do FFmpeg: ${ffmpegErr.message}`);
-      if (ffmpegErr.stderr) {
-        logger.error(`FFmpeg stderr: ${ffmpegErr.stderr}`);
-      }
-      throw new Error(`Falha ao converter mídia para sticker (FFmpeg): ${ffmpegErr.message}`);
-    }
-    if (ffmpegResult && ffmpegResult.stderr) {
-      logger.debug(`FFmpeg stderr: ${ffmpegResult.stderr}`);
-    }
-    await fs.access(outputPath);
-    logger.info(`StickerCommand Conversão bem-sucedida para: ${outputPath}`);
-    return outputPath;
-  } catch (error) {
-    logger.error(`StickerCommand.convertToWebp Erro na conversão: ${error.message}`, {
-      error: error.stack,
-    });
-    throw new Error(`Erro na conversão para webp: ${error.message}`);
-  }
 }
 
 /**

--- a/app/modules/stickerModule/stickerCommand.js
+++ b/app/modules/stickerModule/stickerCommand.js
@@ -66,7 +66,7 @@ function extractMediaDetails(message) {
   };
 
   const media = findMedia(messageContent) || findMedia(quotedMessage, true);
-  if (!media) logger.debug('StickerCommand.extractMediaDetails Nenhuma mídia encontrada.');
+  if (!media) logger.debug('extractMediaDetails Nenhuma mídia encontrada.');
   return media;
 }
 
@@ -81,9 +81,9 @@ function extractMediaDetails(message) {
 function checkMediaSize(mediaKey, mediaType, maxFileSize = MAX_FILE_SIZE) {
   const fileLength = mediaKey?.fileLength || 0;
   const formatBytes = (bytes) => (bytes / (1024 * 1024)).toFixed(2) + ' MB';
-  logger.debug(`StickerCommand.checkMediaSize Verificando tamanho: ${formatBytes(fileLength)}`);
+  logger.debug(`checkMediaSize Verificando tamanho: ${formatBytes(fileLength)}`);
   if (fileLength > maxFileSize) {
-    logger.warn(`StickerCommand.checkMediaSize Mídia muito grande: ${formatBytes(fileLength)}`);
+    logger.warn(`checkMediaSize Mídia muito grande: ${formatBytes(fileLength)}`);
     return false;
   }
   return true;
@@ -146,7 +146,7 @@ async function processSticker(sock, messageInfo, senderJid, remoteJid, expiratio
 
     const dirResult = await ensureDirectories(formattedUser);
     if (!dirResult.success) {
-      logger.error(`StickerCommand Erro ao garantir diretórios: ${dirResult.error}`);
+      logger.error(`processSticker Erro ao garantir diretórios: ${dirResult.error}`);
       await sock.sendMessage(adminJid, { text: `❌ Erro ao preparar diretórios do usuário: ${dirResult.error}` });
       return;
     }
@@ -203,7 +203,7 @@ async function processSticker(sock, messageInfo, senderJid, remoteJid, expiratio
     const mediaExtension = path.extname(tempMediaPath);
     processingMediaPath = path.join(userStickerDir, `media_${uniqueId}${mediaExtension}`);
     await fs.rename(tempMediaPath, processingMediaPath);
-    logger.info(`StickerCommand Mídia original renomeada para: ${processingMediaPath}`);
+    logger.info(`processSticker Mídia original renomeada para: ${processingMediaPath}`);
     tempMediaPath = null;
 
     stickerPath = await convertToWebp(processingMediaPath, mediaType, formattedUser, uniqueId);
@@ -215,7 +215,7 @@ async function processSticker(sock, messageInfo, senderJid, remoteJid, expiratio
     try {
       stickerBuffer = await fs.readFile(stickerPath);
     } catch (bufferErr) {
-      logger.error(`StickerCommand Erro ao ler buffer do sticker: ${bufferErr.message}`);
+      logger.error(`processSticker Erro ao ler buffer do sticker: ${bufferErr.message}`);
       const msgErro = '*❌ Não foi possível finalizar o sticker.*\n\n- Ocorreu um erro ao acessar o arquivo temporário do sticker.\n- Tente reenviar a mídia ou envie outro arquivo.';
       await sock.sendMessage(from, { text: msgErro }, { quoted: message });
       if (adminJid) {
@@ -228,7 +228,7 @@ async function processSticker(sock, messageInfo, senderJid, remoteJid, expiratio
     try {
       await sock.sendMessage(from, { sticker: stickerBuffer }, { quoted: message });
     } catch (sendErr) {
-      logger.error(`StickerCommand Erro ao enviar o sticker: ${sendErr.message}`);
+      logger.error(`processSticker Erro ao enviar o sticker: ${sendErr.message}`);
       const msgErro = '*❌ Não foi possível enviar o sticker ao chat.*\n\n- Ocorreu um erro inesperado ao tentar enviar o arquivo.\n- Tente novamente ou envie outra mídia.';
       await sock.sendMessage(from, { text: msgErro }, { quoted: message });
       if (adminJid) {
@@ -238,7 +238,7 @@ async function processSticker(sock, messageInfo, senderJid, remoteJid, expiratio
       }
     }
   } catch (error) {
-    logger.error(`StickerCommand Erro ao processar sticker: ${error.message}`, {
+    logger.error(`processSticker Erro ao processar sticker: ${error.message}`, {
       error: error.stack,
     });
     const msgErro = '*❌ Não foi possível criar o sticker.*\n\n- Ocorreu um erro inesperado durante o processamento.\n- Tente novamente ou envie outra mídia.';
@@ -251,7 +251,7 @@ async function processSticker(sock, messageInfo, senderJid, remoteJid, expiratio
   } finally {
     const filesToClean = [tempMediaPath, processingMediaPath, stickerPath].filter(Boolean);
     for (const file of filesToClean) {
-      await fs.unlink(file).catch((err) => logger.warn(`StickerCommand Falha ao limpar arquivo temporário ${file}: ${err.message}`));
+      await fs.unlink(file).catch((err) => logger.warn(`processSticker Falha ao limpar arquivo temporário ${file}: ${err.message}`));
     }
   }
 }


### PR DESCRIPTION
Introduces functionality to save and recall the last used sticker pack name and author for each user. This enhances convenience, allowing users to create stickers without repeatedly specifying pack details if they wish to use their previously defined metadata. If a user provides new metadata in the command text, it updates their saved preference for future use.