### PR TITLE
Makes command parsing case-insensitive

### DIFF
--- a/app/controllers/messageController.js
+++ b/app/controllers/messageController.js
@@ -142,7 +142,7 @@ const handleMessages = async (update, sock) => {
         if (extractedText.startsWith(COMMAND_PREFIX)) {
           const commandBody = extractedText.substring(COMMAND_PREFIX.length);
           const match = commandBody.match(/^(\S+)([\s\S]*)$/);
-          const command = match ? match[1] : '';
+          const command = match ? match[1].toLowerCase() : '';
           const args = match && match[2] !== undefined ? [match[2].trimStart()] : [];
 
           const isGroupMessage = messageInfo.key.remoteJid.endsWith('@g.us');

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "omnizap-system",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@hapi/boom": "^10.0.1",


### PR DESCRIPTION
Converts extracted commands to lowercase before processing. This ensures that commands are recognized regardless of their casing, improving the robustness and user-friendliness of command handling.